### PR TITLE
Fix up build on AIX7

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -20,6 +20,31 @@
 
 #include <stddef.h>
 
+#include "platform.hpp"
+
+#if defined ZMQ_FORCE_SELECT
+#define ZMQ_POLL_BASED_ON_SELECT
+#elif defined ZMQ_FORCE_POLL
+#define ZMQ_POLL_BASED_ON_POLL
+#elif defined ZMQ_HAVE_LINUX || defined ZMQ_HAVE_FREEBSD ||\
+    defined ZMQ_HAVE_OPENBSD || defined ZMQ_HAVE_SOLARIS ||\
+    defined ZMQ_HAVE_OSX || defined ZMQ_HAVE_QNXNTO ||\
+    defined ZMQ_HAVE_HPUX || defined ZMQ_HAVE_AIX ||\
+    defined ZMQ_HAVE_NETBSD
+#define ZMQ_POLL_BASED_ON_POLL
+#elif defined ZMQ_HAVE_WINDOWS || defined ZMQ_HAVE_OPENVMS ||\
+     defined ZMQ_HAVE_CYGWIN
+#define ZMQ_POLL_BASED_ON_SELECT
+#endif
+
+//  On AIX platform, poll.h has to be included first to get consistent
+//  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
+//  instead of 'events' and 'revents' and defines macros to map from POSIX-y
+//  names to AIX-specific names).
+#if defined ZMQ_POLL_BASED_ON_POLL
+#include <poll.h>
+#endif
+
 #include "../include/zmq.h"
 
 #include "device.hpp"

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #define ZMQ_TYPE_UNSAFE
-#include "../include/zmq.h"
 
 #include "platform.hpp"
 
@@ -45,6 +44,9 @@
 #if defined ZMQ_POLL_BASED_ON_POLL
 #include <poll.h>
 #endif
+
+// zmq.h must be included *after* poll.h for AIX to build properly
+#include "../include/zmq.h"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"


### PR DESCRIPTION
Copy logic from zmq.cpp into device.cpp for getting poll.h included.

Ensure that zmq.h is included _after_ poll.h in both zmq.cpp and
device.cpp.
