### PR TITLE
Fix build on RHEL5 and SLES10

### DIFF
--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -123,3 +123,4 @@ int main (int argc, char *argv [])
 
     return 0 ;
 }
+


### PR DESCRIPTION
GCC 4.1.2 on RHEL5 and SLES10 don't like not having a newline at the
end of a source file, and error out if it's missing.
