### PR TITLE
Fix invalid address metadata for ZMQ_EVENT_DISCONNECTED

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -97,9 +97,8 @@ void zmq::ipc_connecter_t::out_event ()
         add_reconnect_timer();
         return;
     }
-
     //  Create the engine object for this connection.
-    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options);
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options, endpoint);
     alloc_assert (engine);
 
     //  Attach the engine to the corresponding session object.

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -82,7 +82,7 @@ void zmq::ipc_listener_t::in_event ()
     }
 
     //  Create the engine object for this connection.
-    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options);
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options, endpoint);
     alloc_assert (engine);
 
     //  Choose I/O thread to run connecter in. Given that we are already
@@ -156,7 +156,7 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     if (rc != 0)
         return -1;
 
-    socket->monitor_event (ZMQ_EVENT_LISTENING, addr_, s);
+    socket->monitor_event (ZMQ_EVENT_LISTENING, endpoint.c_str(), s);
     return 0;
 }
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -265,13 +265,6 @@ void zmq::session_base_t::hiccuped (pipe_t *pipe_)
     zmq_assert (false);
 }
 
-int zmq::session_base_t::get_address (std::string &addr_)
-{
-    if (addr)
-        return addr->to_string (addr_);
-    return -1;
-}
-
 void zmq::session_base_t::monitor_event (int event_, ...)
 {
     va_list args;

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -66,7 +66,6 @@ namespace zmq
         void hiccuped (zmq::pipe_t *pipe_);
         void terminated (zmq::pipe_t *pipe_);
 
-        int get_address (std::string &addr_);
         void monitor_event (int event_, ...);
 
     protected:

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -45,7 +45,7 @@ namespace zmq
     {
     public:
 
-        stream_engine_t (fd_t fd_, const options_t &options_);
+        stream_engine_t (fd_t fd_, const options_t &options_, const std::string &endpoint);
         ~stream_engine_t ();
 
         //  i_engine interface implementation.

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -111,7 +111,7 @@ void zmq::tcp_connecter_t::out_event ()
     tune_tcp_keepalives (fd, options.tcp_keepalive, options.tcp_keepalive_cnt, options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
 
     //  Create the engine object for this connection.
-    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options);
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options, endpoint);
     alloc_assert (engine);
 
     //  Attach the engine to the corresponding session object.

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -93,7 +93,7 @@ void zmq::tcp_listener_t::in_event ()
     tune_tcp_keepalives (fd, options.tcp_keepalive, options.tcp_keepalive_cnt, options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
 
     //  Create the engine object for this connection.
-    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options);
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (fd, options, endpoint);
     alloc_assert (engine);
 
     //  Choose I/O thread to run connecter in. Given that we are already

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -21,6 +21,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include "testutil.hpp"
 
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
@@ -98,6 +99,8 @@ int main (int argc, char *argv [])
     rc = zmq_connect (req, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
+    bounce (rep, req);
+
     // Allow a window for socket events as connect can be async
     zmq_sleep (1);
 
@@ -120,6 +123,7 @@ int main (int argc, char *argv [])
     assert (events & ZMQ_EVENT_ACCEPTED);
     assert (events & ZMQ_EVENT_CONNECTED);
     assert (events & ZMQ_EVENT_CLOSED);
+    assert (events & ZMQ_EVENT_DISCONNECTED);
 
     return 0 ;
 }


### PR DESCRIPTION
Fixes invalid address metadata as noted in https://zeromq.jira.com/browse/LIBZMQ-399
