### PR TITLE
backport PR388 from libzmq

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -341,6 +341,8 @@ ZMQ_EXPORT int zmq_sendmsg (void *s, zmq_msg_t *msg, int flags);
 ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
 
 /*  Experimental                                                              */
+struct iovec;
+
 ZMQ_EXPORT int zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
 ZMQ_EXPORT int zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
 


### PR DESCRIPTION
forward-declare struct iovec in zmq.h

avoids warnings of the form:

warning: 'struct iovec' declared inside parameter list warning: its scope is
only this definition or declaration, which is probably not what you want

when building downstream projects
