### PR TITLE
socket_base: fix 'va_list' has not been declared error

### DIFF
--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <map>
+#include <cstdarg>
 
 #include "own.hpp"
 #include "array.hpp"


### PR DESCRIPTION
This patches tries to fix following compile error with gcc 4.7.1/uClibc 0.9.33.2
on ARM (OpenWRT):

```
In file included from device.cpp:51:0:
socket_base.hpp:105:35: error: 'va_list' has not been declared
make[5]: *** [libzmq_la-device.lo] Error 1
```

Signed-off-by: Petr Štetiar ynezz@true.cz
