### PR TITLE
Revert zmq_poll NULL poll items check to 2.2 behavior - let the poll items count filter out empty poll sets and not return a sometimes unexpected EFAULT error status

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -608,10 +608,6 @@ int zmq_msg_set (zmq_msg_t *msg_, int option_, int optval_)
 
 int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
 {
-    if (!items_) {
-        errno = EFAULT;
-        return -1;
-    }
 #if defined ZMQ_POLL_BASED_ON_POLL
     if (unlikely (nitems_ < 0)) {
         errno = EINVAL;
@@ -630,6 +626,12 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
         return usleep (timeout_ * 1000);
 #endif
     }
+
+    if (!items_) {
+        errno = EFAULT;
+        return -1;
+    }
+
     zmq::clock_t clock;
     uint64_t now = 0;
     uint64_t end = 0;


### PR DESCRIPTION
Backports from libzmq ( https://github.com/zeromq/libzmq/pull/403 )
