### PR TITLE
Resolve LIBZMQ-438 

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -59,7 +59,7 @@ void zmq::decoder_t::set_session (session_base_t *session_)
 
 bool zmq::decoder_t::stalled () const
 {
-    return next == &decoder_t::message_ready;
+    return to_read == 0;
 }
 
 bool zmq::decoder_t::one_byte_size_ready ()

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -52,9 +52,9 @@ namespace zmq
     public:
 
         inline decoder_base_t (size_t bufsize_) :
+            to_read (0),
             next (NULL),
             read_pos (NULL),
-            to_read (0),
             bufsize (bufsize_)
         {
             buf = (unsigned char*) malloc (bufsize_);
@@ -165,18 +165,18 @@ namespace zmq
             next = NULL;
         }
 
+        //  How much data to read before taking next step.
+        size_t to_read;
+
+    private:
+
         //  Next step. If set to NULL, it means that associated data stream
         //  is dead. Note that there can be still data in the process in such
         //  case.
         step_t next;
 
-    private:
-
         //  Where to store the read data.
         unsigned char *read_pos;
-
-        //  How much data to read before taking next step.
-        size_t to_read;
 
         //  The duffer for data to decode.
         size_t bufsize;

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -131,7 +131,8 @@ void zmq::stream_engine_t::unplug ()
     plugged = false;
 
     //  Cancel all fd subscriptions.
-    rm_fd (handle);
+    if (!input_error)
+        rm_fd (handle);
 
     //  Disconnect from I/O threads poller object.
     io_object_t::unplug ();
@@ -197,7 +198,7 @@ void zmq::stream_engine_t::in_event ()
     if (disconnection) {
         input_error = true;
         if (decoder.stalled ())
-            reset_pollin (handle);
+            rm_fd (handle);
         else
             error ();
     }


### PR DESCRIPTION
- fix detection of stalled decoder
- remove a socket from the poller on error immediately

Ref: https://zeromq.jira.com/browse/LIBZMQ-438
