### PR TITLE
Backported fix for LIBZMQ-497

### DIFF
--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -126,6 +126,11 @@ namespace zmq
             *size_ = pos;
         }
 
+        inline bool has_data ()
+        {
+            return to_write > 0;
+        }
+
     protected:
 
         //  Prototype of state machine action.

--- a/src/i_encoder.hpp
+++ b/src/i_encoder.hpp
@@ -47,6 +47,7 @@ namespace zmq
         virtual void get_data (unsigned char **data_, size_t *size_,
             int *offset_ = NULL) = 0;
 
+        virtual bool has_data () = 0;
     };
 
 }

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -135,6 +135,7 @@ namespace zmq
         std::string endpoint;
 
         bool plugged;
+        bool terminating;
 
         // Socket
         zmq::socket_base_t *socket;


### PR DESCRIPTION
When we send a large message, the message can be splitted into two chunks.
One is in the encoder buffer and the other is the zero-copy pointer.
The session could get the term before the last chunk is sent.
