### PR TITLE
Work around for LIBZMQ-496

### DIFF
--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -35,6 +35,11 @@ zmq::mailbox_t::mailbox_t ()
 zmq::mailbox_t::~mailbox_t ()
 {
     //  TODO: Retrieve and deallocate commands inside the cpipe.
+
+    // Work around problem that other threads might still be in our
+    // send() method, by waiting on the mutex before disappearing.
+    sync.lock ();
+    sync.unlock ();
 }
 
 zmq::fd_t zmq::mailbox_t::get_fd ()


### PR DESCRIPTION
The problem is that other threads might still be in mailbox::send() when
it is destroyed. So as a workaround, we just acquire the mutex in the
destructor. Therefore the running send will finish before the mailbox is
destroyed.

See also the fix for LIBZMQ-281 in zeromq2-x.

Signed-off-by: Mika Fischer mika.fischer@zoopnet.de
