### PR TITLE
[LIBZMQ-543] Fix compilation errors with Clang

### DIFF
--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -35,8 +35,6 @@
 namespace zmq
 {
 
-    class i_msg_sink;
-
     //  Helper base class for decoders that know the amount of data to read
     //  in advance at any moment. Knowing the amount in advance is a property
     //  of the protocol used. 0MQ framing protocol is based size-prefixed

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -40,8 +40,6 @@
 namespace zmq
 {
 
-    class i_msg_source;
-
     //  Helper base class for encoders. It implements the state machine that
     //  fills the outgoing buffer. Derived classes should implement individual
     //  state machine actions.

--- a/src/i_decoder.hpp
+++ b/src/i_decoder.hpp
@@ -26,7 +26,8 @@
 namespace zmq
 {
 
-    class i_msg_sink;
+    // Forward declaration
+    struct i_msg_sink;
 
     //  Interface to be implemented by message decoder.
 

--- a/src/i_encoder.hpp
+++ b/src/i_encoder.hpp
@@ -27,7 +27,7 @@ namespace zmq
 {
 
     //  Forward declaration
-    class i_msg_source;
+    struct i_msg_source;
 
     //  Interface to be implemented by message encoder.
 

--- a/src/v1_encoder.hpp
+++ b/src/v1_encoder.hpp
@@ -29,8 +29,6 @@
 namespace zmq
 {
 
-    class i_msg_source;
-
     //  Encoder for 0MQ framing protocol. Converts messages into data stream.
 
     class v1_encoder_t : public encoder_base_t <v1_encoder_t>


### PR DESCRIPTION
A few forward declarations use mismatched struct and class types. Clang won't compile this with -Werror (which is enabled by default).
