### PR TITLE
Backport for LIBZMQ-541 fix

### DIFF
--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -80,12 +80,19 @@ void zmq::dist_t::terminated (pipe_t *pipe_)
 {
     //  Remove the pipe from the list; adjust number of matching, active and/or
     //  eligible pipes accordingly.
-    if (pipes.index (pipe_) < matching)
+    if (pipes.index (pipe_) < matching) {
+        pipes.swap (pipes.index (pipe_), matching - 1);
         matching--;
-    if (pipes.index (pipe_) < active)
+    }
+    if (pipes.index (pipe_) < active) {
+        pipes.swap (pipes.index (pipe_), active - 1);
         active--;
-    if (pipes.index (pipe_) < eligible)
+    }
+    if (pipes.index (pipe_) < eligible) {
+        pipes.swap (pipes.index (pipe_), eligible - 1);
         eligible--;
+    }
+
     pipes.erase (pipe_);
 }
 


### PR DESCRIPTION
Backport for LIBZMQ-541 fix (https://github.com/zeromq/libzmq/pull/601)

1.In the pub socket, There is zmq::dist_t::write() failed pipe. this pipe will moved last index of pipe array and to-be-removed.
2.Another pipe is in zmq::dist_t::terminated(). To-be-removed pipe will moved in the middle of array.
3.After the pipe was erased, sometimes the existed active pipe array index will have equal or greater number than eligible number. So, this active pipe cannot be sent,

solution : The active status pipe index must be located in less array index than eligible number. For that, Added swap before erase in the terminated() function.
