### PR TITLE
Fix race to crash: when a message is sent as the last connection is lost

### DIFF
--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -113,7 +113,8 @@ int zmq::lb_t::send (msg_t *msg_, int flags_)
     more = msg_->flags () & msg_t::more? true: false;
     if (!more) {
         pipes [current]->flush ();
-        current = (current + 1) % active;
+        if (++current >= active)
+            current = 0;
     }
 
     //  Detach the message from the data buffer.


### PR DESCRIPTION
Active is reduced in the zmq internal thread in terminated(), potentially to zero.
If the user thread is in send() between lines 109 and 116, then the old code "(current+1) % active" is a divide by 0 - and crashes the program.
