### PR TITLE
tests: add proper include for nanosleep() on FreeBSD

### DIFF
--- a/tests/test_connect_delay.cpp
+++ b/tests/test_connect_delay.cpp
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
 #include <string>
 
 #undef NDEBUG


### PR DESCRIPTION
Patch has been in the ports tree for quite a while, it may be
useful to push it upstream.  :)