### PR TITLE
Update stream_engine.hpp

### DIFF
--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -94,7 +94,7 @@ namespace zmq
 
         //  Size of the greeting message:
         //  Preamble (10 bytes) + version (1 byte) + socket type (1 byte).
-        const static size_t greeting_size = 12;
+        static const size_t greeting_size = 12;
 
         //  True iff we are registered with an I/O poller.
         bool io_enabled;


### PR DESCRIPTION
The Intel compiler  (icc) complains about the order of "static" and "const". The fix is a simple switch to one line in one header file.

In file included from ipc_listener.cpp(29):
stream_engine.hpp(97): error #82: storage class is not first
          const static size_t greeting_size = 12;